### PR TITLE
feat: remove disable screenshot flag

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -2,11 +2,6 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
   const height = process.env.HEIGHT || '1280'
   const width = process.env.WIDTH || '720'
 
-  // Disable duplicate screenshot on failure of visual regression test
-  Cypress.Screenshot.defaults({
-    screenshotOnRunFailure: false
-  })
-  
   // Force screenshot resolution to keep consistency of test runs across machines
   Cypress.config('viewportHeight', height)
   Cypress.config('viewportWidth', width)


### PR DESCRIPTION
Remove the default cypress screenshot flag as it is up to the user to disable it when needed.