### PR TITLE
update height and width values of Cypress config

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,6 +1,6 @@
 const compareSnapshotCommand = defaultScreenshotOptions => {
-  const height = process.env.HEIGHT || '1440'
-  const width = process.env.WIDTH || '1980'
+  const height = process.env.HEIGHT || 1440
+  const width = process.env.WIDTH || 1980
 
   // Force screenshot resolution to keep consistency of test runs across machines
   Cypress.config('viewportHeight', height)


### PR DESCRIPTION
Starting Cypress 9, it will throw an error if Cypress.config validation is incorrect. Reference - https://github.com/cypress-io/cypress/pull/18589

This is the error we have on our current project:
![image](https://user-images.githubusercontent.com/25013382/141256735-c68a3de5-c402-4697-8ae9-e790e5b2ce5a.png)
