### PR TITLE
fix: swap width/height, support electron and firefox

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -90,11 +90,19 @@ const getCompareSnapshotsPlugin = on => {
 
   // Force screenshot resolution to keep consistency of test runs across machines
   on('before:browser:launch', (browser, launchOptions) => {
-    const height = process.env.HEIGHT || '1280'
-    const width = process.env.WIDTH || '720'
+    const width = process.env.WIDTH || '1280'
+    const height = process.env.HEIGHT || '720'
     if (browser.name === 'chrome') {
-      launchOptions.args.push(`--window-size=${height},${width}`)
+      launchOptions.args.push(`--window-size=${width},${height}`)
       launchOptions.args.push('--force-device-scale-factor=1')
+    }
+    if (browser.name === 'electron') {
+      launchOptions.preferences.width = width
+      launchOptions.preferences.height = height
+    }
+    if (browser.name === 'firefox') {
+      launchOptions.args.push(`--width=${width}`)
+      launchOptions.args.push(`--height=${height}`)
     }
     return launchOptions
   })


### PR DESCRIPTION
Thanks for the great plugin. Super concise code!

Looking at [this example code](https://docs.cypress.io/api/plugins/browser-launch-api#Set-screen-size-when-running-headless) from the Cypress documentation, it looks like width and height are swapped. I've fixed this and also added support for firefox and electron runners.