### PR TITLE
fix: electron requires numbers as parameters

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -98,9 +98,9 @@ const getCompareSnapshotsPlugin = on => {
     }
     if (browser.name === 'electron') {
       // eslint-disable-next-line no-param-reassign
-      launchOptions.preferences.width = width
+      launchOptions.preferences.width = Number.parseInt(width, 10)
       // eslint-disable-next-line no-param-reassign
-      launchOptions.preferences.height = height
+      launchOptions.preferences.height = Number.parseInt(height, 10)
     }
     if (browser.name === 'firefox') {
       launchOptions.args.push(`--width=${width}`)


### PR DESCRIPTION
Hello,
Thank you for your great library.

This is just a little fix for electron use.
Electron expects its width and height as integer, not as string.

I tested this on Windows 10 and Ubuntu 21.04.
Linted and Tests pass. 

Best wishes,
Andreas