### PR TITLE
Fix: Reporting and Retries

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -26,8 +26,9 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
 
       recurse(
         () => {
-          // Clear the comparison and diff screenshots for this test
+          // Clear the comparison/diff screenshots/reports for this test
           cy.task('deleteScreenshot', { testName })
+          cy.task('deleteReport', { testName })
 
           // Take a screenshot and copy to baseline if it does not exist
           const objToOperateOn = subject ? cy.get(subject) : cy

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -12,7 +12,7 @@ import paths from './config'
 import TestStatus from './reporter/test-status'
 import { createReport } from './reporter'
 
-const testStatuses = []
+let testStatuses = []
 
 const setupFolders = () => {
   createDir([paths.dir.baseline, paths.dir.comparison, paths.dir.diff, paths.reportDir])
@@ -26,6 +26,12 @@ const generateReport = (instance = '') => {
   if (testStatuses.length > 0) {
     createReport({ tests: testStatuses, instance })
   }
+  return true
+}
+
+const deleteReport = args => {
+  testStatuses = testStatuses.filter(testStatus => testStatus.name !== args.testName)
+
   return true
 }
 
@@ -135,6 +141,7 @@ const getCompareSnapshotsPlugin = on => {
     copyScreenshot,
     deleteScreenshot,
     generateReport,
+    deleteReport,
   })
 }
 


### PR DESCRIPTION
I created a bug with reporting in #63. Each time we call `cy.compareScreenshot` a new `TestStatus` object gets added. However, if we are retrying `cy.compareScreenshot` over and over, we only care about the last `TestStatus` (for the same reason we only care about the last screenshot taken).

We just need to clear the previous `TestStatus` the same way we clear the previous comparison/diff screenshot.

`main`

https://user-images.githubusercontent.com/13155517/147292991-d86f5db6-8535-47d4-942f-4ba97ef8fb34.mp4


`fix/retry-reporting`

https://user-images.githubusercontent.com/13155517/147292999-dcf62525-c12a-4bfb-8de3-b334b9845f61.mp4

