### PR TITLE
fix: use cypress config to force resolution viewport size everywhere

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,8 +1,8 @@
 import { recurse } from 'cypress-recurse';
 
 const compareSnapshotCommand = defaultScreenshotOptions => {
-  const height = process.env.HEIGHT || 1440
-  const width = process.env.WIDTH || 1980
+  const height = Cypress.config('viewportHeight') || 1440
+  const width = Cypress.config('viewportWidth') || 1980
 
   // Force screenshot resolution to keep consistency of test runs across machines
   Cypress.config('viewportHeight', parseInt(height, 10))


### PR DESCRIPTION
fix #68 
and
fix #74 

properly as command.js was still reading from the environment variables instead of the cypress.json before using the fallback sizes