### PR TITLE
Add param to preserve original screenshot location

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ In order to force the screenshot resolution when running a test you will need to
 }
 ```
 
+### Preserving the original screenshot
+All screenshots will be renamed and moved from the default screenshot location to a new screenshot folder structure. To preserve the screenshot in the original location, set the following values in `cypress.json`:
+
+```json
+{
+  "env": {
+    "preserveOriginalScreenshot": true
+  }
+}
+```
+
 ### Please notice
 
 Be aware that despite forcing a screenshot resolution to a particular height and width for a test, if this test is run on different computers (i.e a 13" Mac vs PC attached to a 30" monitor), the results will be different. So it's extremely important that you standardize where the tests will run, both locally and CI.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,12 +2,14 @@ import fs from 'fs-extra'
 import pixelmatch from 'pixelmatch'
 import { PNG } from 'pngjs'
 
-import { createDir,
-         cleanDir,
-         adjustCanvas,
-         parseImage,
-         setFilePermission,
-         renameAndMoveFile } from './utils'
+import {
+  createDir,
+  cleanDir,
+  adjustCanvas,
+  parseImage,
+  setFilePermission,
+  renameAndMoveFile, renameAndCopyFile
+} from './utils'
 import paths from './config'
 import TestStatus from './reporter/test-status'
 import { createReport } from './reporter'
@@ -135,7 +137,12 @@ const getCompareSnapshotsPlugin = (on, config) => {
     // Change screenshots file permission so it can be moved from drive to drive
     setFilePermission(details.path, 0o777)
     setFilePermission(paths.image.comparison(details.name), 0o777)
-    renameAndMoveFile(details.path, paths.image.comparison(details.name))
+
+    if (config.env.preserveOriginalScreenshot === true) {
+      renameAndCopyFile(details.path, paths.image.comparison(details.name))
+    } else {
+      renameAndMoveFile(details.path, paths.image.comparison(details.name))
+    }
   })
 
   on('task', {

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,6 +38,10 @@ const renameAndMoveFile = (originalFilePath, newFilePath) => {
   fs.moveSync(originalFilePath, newFilePath, {overwrite: true})
 }
 
+const renameAndCopyFile = (originalFilePath, newFilePath) => {
+  fs.copySync(originalFilePath, newFilePath, {overwrite: true})
+}
+
 const parseImage = async image => {
   return new Promise((resolve, reject) => {
     const fd = fs.createReadStream(image)
@@ -68,4 +72,4 @@ const adjustCanvas = async (image, width, height) => {
   return imageAdjustedCanvas
 }
 
-export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile }
+export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, emptyDirSync, readdirSync, moveSync } from 'fs-extra'
-import { createDir, cleanDir, renameAndMoveFile } from './utils'
+import { existsSync, mkdirSync, emptyDirSync, readdirSync, moveSync, copySync } from 'fs-extra'
+import { createDir, cleanDir, renameAndMoveFile, renameAndCopyFile } from './utils'
 
 jest.mock('fs-extra', () => ({
   ...jest.requireActual('fs-extra'),
@@ -8,6 +8,7 @@ jest.mock('fs-extra', () => ({
   emptyDirSync: jest.fn(),
   readdirSync: jest.fn(),
   moveSync: jest.fn(),
+  copySync: jest.fn(),
 }))
 
 describe('Utils', () => {
@@ -61,6 +62,14 @@ describe('Utils', () => {
       renameAndMoveFile(sampleFiles[0], sampleFiles[1])
       expect(moveSync).toHaveBeenCalledTimes(1)
       expect(moveSync).toBeCalledWith(sampleFiles[0], sampleFiles[1], {"overwrite": true})
+    })
+  })
+
+  describe('Copy files', () => {
+    it('should copy files', () => {
+      renameAndCopyFile(sampleFiles[0], sampleFiles[1])
+      expect(copySync).toHaveBeenCalledTimes(1)
+      expect(copySync).toBeCalledWith(sampleFiles[0], sampleFiles[1], {"overwrite": true})
     })
   })
 })


### PR DESCRIPTION
It may be useful to preserve the screenshots in their original location rather that moving it under the new screenshot folder structure. This will provide an option for addressing the failure screenshots becoming undefined files under the new folder structure and any other incompatibilities with reporting plugins that might be expecting screenshots in the standard Cypress location.