### PR TITLE
feat: Add compareSnapshot option to allow test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ describe('Visuals', () => {
 })
 ```
 
+Additionally, you can also pass run options, where you can allow comparison to fail. This is useful if you want to generate visual test report, but do not want to fail whole cypress suite in case of failure.
+
+```js
+describe('Visuals', () => {
+  it('should compare screenshot of the entire page', () => {
+    cy.visit('www.google.com')
+    cy.compareSnapshot('home-page-with-threshold', {threshold: 0.2, allowToFail: true})
+  })
+})
+```
+
+
 You can also retry the snapshot comparison by passing in an optional third parameter. It accepts the same options as [cypress-recurse](https://github.com/bahmutov/cypress-recurse#options).
 
 ```js

--- a/cypress/specs/image-diff-spec.js
+++ b/cypress/specs/image-diff-spec.js
@@ -12,6 +12,11 @@ describe('Visuals', () => {
     cy.visit('../../report-example.html')
     cy.compareSnapshot('wholePageThreshold', 0.2)
   })
+
+  it('should not fail test if allowToFail option is paassed', () => {
+    cy.visit('../../report-example.html')
+    cy.compareSnapshot('wholePageThreshold', {threshold: -1, allowToFail: true})
+  })
   
   it('should compare screenshot from a given element', () => {
     cy.visit('../../report-example.html')

--- a/src/command.js
+++ b/src/command.js
@@ -11,7 +11,15 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
   Cypress.Commands.add(
     'compareSnapshot',
     { prevSubject: 'optional' },
-    (subject, name, testThreshold = 0, recurseOptions = {}) => {
+    (subject, name, optionsOrThreshold, recurseOptions = {}) => {
+      let testThreshold;
+      let allowToFail = false;
+      if (typeof optionsOrThreshold === 'object') {
+          testThreshold = optionsOrThreshold.threshold || 0;
+          allowToFail = !!optionsOrThreshold.allowToFail;
+      } else {
+          testThreshold = optionsOrThreshold || 0;
+      }
       const specName = Cypress.spec.name
       const testName = `${specName.replace('.js', '')}-${name}`
 
@@ -42,6 +50,7 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
           const options = {
             testName,
             testThreshold,
+            allowToFail
           }
           
           return cy.task('compareSnapshotsPlugin', options)

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -94,8 +94,10 @@ async function compareSnapshotsPlugin(args) {
     diff.pack().pipe(fs.createWriteStream(paths.image.diff(args.testName)))
   }
 
-  // Saving test status object to build report if task is triggered
-  testStatuses.push(new TestStatus(!testFailed, args.testName))
+   if (!args.allowToFail) {
+     // Saving test status object to build report if task is triggered
+     testStatuses.push(new TestStatus(!testFailed, args.testName))
+   }
 
   return percentage
 }


### PR DESCRIPTION
This is useful when you want to just generate full report with failed snapshots. 

Our project is changing fast and forcing all visual tests to fail makes it hard to maintain visual tests. We would like to use cypress-image-diff to review all visual changes periodically, but we do not want to fail full e2e test suite each time.

Sorry for not contacting to about this feature earlier, but it's a simple change so I just created and we can discuss it in this MR.

This changes api a bit (adds options object instead of threshold) but it is fully backward compatible.