### PR TITLE
docs: add documentation on Cypress 10 setup

### DIFF
--- a/docs/Cypress integration.md
+++ b/docs/Cypress integration.md
@@ -6,27 +6,45 @@ Follow the steps below to have access to the comparison command so you can build
 
 Install cypress:
 
-`npm i -D cypress`
+```sh
+npm i -D cypress
+```
 
 Install the package:
 
-`npm i -D cypress-image-diff-js`
+```sh
+npm i -D cypress-image-diff-js
+```
 
 Then initialise cypress if you don't have a project:
 
-`npx cypress open`
-
+```sh
+npx cypress open
+```
 
 ## Cypress plugin
 
 import and initialise the cypress image diff plugin:
 
 ```js
+// Versions below Cypress 10
 // cypress/plugin/index.js
 module.exports = (on, config) => {
   const getCompareSnapshotsPlugin = require('cypress-image-diff-js/dist/plugin')
   getCompareSnapshotsPlugin(on, config)
 }
+
+// Cypress 10 and above
+// cypress.config.js
+const getCompareSnapshotsPlugin = require "cypress-image-diff-js/dist/plugin");
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      getCompareSnapshotsPlugin(on, config);
+    }
+  },
+});
 ```
 
 ## Cypress support
@@ -34,6 +52,7 @@ module.exports = (on, config) => {
 import and add cypress image command:
 
 ```js
+// Identical setup for versions below 10 and above
 // cypress/support/commands.js
 const compareSnapshotCommand = require('cypress-image-diff-js/dist/command')
 compareSnapshotCommand()
@@ -42,6 +61,7 @@ compareSnapshotCommand()
 ensure to require the commands file:
 
 ```js
-// cypress/support/index.js
+// cypress/support/index.js for Cypress versions below 10
+// cypress/support/{scheme}.js for Cypress versions 10 and above, where {scheme} defaults to e2e
 require('./commands')
 ```

--- a/docs/Reporting.md
+++ b/docs/Reporting.md
@@ -6,9 +6,11 @@ Baseline, comparison and diff images will only be added to the report for failin
 
 ## Cypress support index
 
-Add the following after hook in `cypress/support/index.js`:
+Add the following after hook
 
-```
+```js
+// cypress/support/index.js for Cypress versions below 10
+// cypress/support/{scheme}.js for Cypress versions 10 and above, where {scheme} defaults to e2e
 after(() => {
   cy.task('generateReport')
 })


### PR DESCRIPTION
This PR adds documentation that hopefully closes #89. I did preliminary testing and found that this library works out of the box with Cypress 10+ with no issues (only tested on 10.3.1, but I agree with @PippoRaimondi that it should work with 10.0.0 and above.)

Additionally, did some reformatting on the `docs/Cypress Integration.md` file to add `sh` tag to the command line installation instructions.

Definitely open to changing and updating the language used.