### PR TITLE
Add TypeScript config docs

### DIFF
--- a/docs/Cypress integration.md
+++ b/docs/Cypress integration.md
@@ -4,7 +4,7 @@ Follow the steps below to have access to the comparison command so you can build
 
 ## Setup
 
-Install cypress:
+Install Cypress:
 
 ```sh
 npm i -D cypress
@@ -16,7 +16,7 @@ Install the package:
 npm i -D cypress-image-diff-js
 ```
 
-Then initialise cypress if you don't have a project:
+Then initialise Cypress if you don't have a project:
 
 ```sh
 npx cypress open
@@ -24,17 +24,10 @@ npx cypress open
 
 ## Cypress plugin
 
-import and initialise the cypress image diff plugin:
+Import and initialise the Cypress image diff plugin:
 
 ```js
-// Versions below Cypress 10
-// cypress/plugin/index.js
-module.exports = (on, config) => {
-  const getCompareSnapshotsPlugin = require('cypress-image-diff-js/dist/plugin')
-  getCompareSnapshotsPlugin(on, config)
-}
-
-// Cypress 10 and above
+// Cypress v10+
 // cypress.config.js
 const getCompareSnapshotsPlugin = require('cypress-image-diff-js/dist/plugin');
 
@@ -42,26 +35,50 @@ export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       getCompareSnapshotsPlugin(on, config);
-    }
+    },
   },
 });
+
+// Cypress v10+ with TypeScript
+// cypress.config.ts
+import getCompareSnapshotsPlugin from 'cypress-image-diff-js/dist/plugin';
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      getCompareSnapshotsPlugin(on, config);
+    },
+  },
+});
+
+// Cypress < v10
+// cypress/plugin/index.js
+module.exports = (on, config) => {
+  const getCompareSnapshotsPlugin = require('cypress-image-diff-js/dist/plugin')
+  getCompareSnapshotsPlugin(on, config)
+};
 ```
 
 ## Cypress support
 
-import and add cypress image command:
+Import and add Cypress image command:
 
 ```js
-// Identical setup for versions below 10 and above
+// Cypress v10+
+// cypress/support/{scheme}.js, where {scheme} defaults to e2e
+const compareSnapshotCommand = require('cypress-image-diff-js/dist/command');
+compareSnapshotCommand();
+
+// or Cypress v10+ with TypeScript
+// cypress/support/{scheme}.ts, where {scheme} defaults to e2e
+import compareSnapshotCommand from 'cypress-image-diff-js/dist/command';
+compareSnapshotCommand();
+
+// Cypress < v10
+// cypress/support/index.js
+require('./commands');
+
 // cypress/support/commands.js
-const compareSnapshotCommand = require('cypress-image-diff-js/dist/command')
-compareSnapshotCommand()
-```
-
-ensure to require the commands file:
-
-```js
-// cypress/support/index.js for Cypress versions below 10
-// cypress/support/{scheme}.js for Cypress versions 10 and above, where {scheme} defaults to e2e
-require('./commands')
+const compareSnapshotCommand = require('cypress-image-diff-js/dist/command');
+compareSnapshotCommand();
 ```


### PR DESCRIPTION
Hi, thanks for this plugin, seems nice! 🙌

A quick PR to add TypeScript config docs for the project and rework for consistency:

1. Move v10+ to the start in second example
2. Eliminate `cypress/support/commands.js` because this is no longer standard in Cypress v10+