### PR TITLE
feat: add rootDir configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Alternatively, you can delete the baseline image that you wish to be updated and
 
 ### Folder structure
 
-Folder structure is hard coded (see below). There will be enhancements coming in to make it configurable:
+This folder structure will be created by default at the root of your project where your `package.json` lives:
 
 ```
     .
@@ -108,6 +108,37 @@ Folder structure is hard coded (see below). There will be enhancements coming in
         ├── baseline
         ├── comparison
         ├── diff
+    ├── cypress-visual-report
+```
+
+In some cases, you may want to specify the root folder for this structure. You could pass `rootDir` option into this plugin setup function. `rootDir` is a path relative to the current working directory.
+
+This is an example for Cypress version 10.0.0 or above. Should be similar for the deprecated plugins file in older version as well:
+```
+// Cypress v10+
+// cypress.config.js
+const getCompareSnapshotsPlugin = require('cypress-image-diff-js/dist/plugin')
+
+export default defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      getCompareSnapshotsPlugin(on, config, {
+        rootDir: 'visual-test/custom-folder-name'
+      })
+    }
+  }
+})
+```
+Output directory:
+```
+    .
+    ├── visual-test
+        ├── custom-folder-name
+            ├── cypress-visual-screenshots
+                ├── baseline
+                ├── comparison
+                ├── diff
+            ├── cypress-visual-report
 ```
 
 ### Force resolution size

--- a/src/config.js
+++ b/src/config.js
@@ -1,26 +1,57 @@
 import path from 'path'
 
-const parentDirFolderName = 'cypress-visual-screenshots'
-const parentDir = path.join(process.cwd(), parentDirFolderName)
-const baseline = path.join(process.cwd(), parentDirFolderName, 'baseline')
-const comparison = path.join(process.cwd(), parentDirFolderName, 'comparison')
-const diff = path.join(process.cwd(), parentDirFolderName, 'diff')
-const reportDir = path.join(process.cwd(), 'cypress-visual-report')
+export class Paths {
+  constructor() {
+    this.rootDir = ''
+    this.screenshotFolderName = 'cypress-visual-screenshots'
+    this.reportFolderName = 'cypress-visual-report'
+  }
 
-const paths = {
-  image: {
-    baseline: (testName) => { return path.join(baseline, `${testName}.png`) },
-    comparison: (testName) => { return path.join(comparison, `${testName}.png`) },
-    diff: (testName) => { return path.join(diff, `${testName}.png`) },
-  },
-  dir: {
-    baseline,
-    comparison,
-    diff,
-  },
-  parentDir,
-  reportDir,
-  report: instance => { return path.join(reportDir, `cypress-visual-report${instance}.html`) },
+  get screenshotDir() {
+    return path.join(this.rootDir, this.screenshotFolderName)
+  }
+
+  get baseline() {
+    return path.join(process.cwd(), this.screenshotDir, 'baseline')
+  }
+
+  get comparison() {
+    return path.join(process.cwd(), this.screenshotDir, 'comparison')
+  }
+
+  get diff() {
+    return path.join(process.cwd(), this.screenshotDir, 'diff')
+  }
+
+  get image() {
+    return {
+      baseline: (testName) => {
+        return path.join(this.baseline, `${testName}.png`)
+      },
+      comparison: (testName) => {
+        return path.join(this.comparison, `${testName}.png`)
+      },
+      diff: (testName) => {
+        return path.join(this.diff, `${testName}.png`)
+      },
+    }
+  }
+
+  get dir() {
+    return {
+      baseline: this.baseline,
+      comparison: this.comparison,
+      diff: this.diff,
+    }
+  }
+
+  get reportDir() {
+    return path.join(process.cwd(), this.rootDir, this.reportFolderName)
+  }
+
+  report(instance) {
+    return path.join(this.reportDir, `cypress-visual-report${instance}.html`)
+  }
 }
 
-export default paths
+export default new Paths()

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,71 @@
+import { Paths } from './config'
+
+describe('Path config', () => {
+  const processCwd = jest.spyOn(process, 'cwd')
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return default folder structure', () => {
+    processCwd.mockReturnValue('User/my-project/')
+
+    const paths = new Paths()
+
+    expect(paths.image.baseline('test')).toBe(
+      'User/my-project/cypress-visual-screenshots/baseline/test.png'
+    )
+    expect(paths.image.comparison('test')).toBe(
+      'User/my-project/cypress-visual-screenshots/comparison/test.png'
+    )
+    expect(paths.image.diff('test')).toBe(
+      'User/my-project/cypress-visual-screenshots/diff/test.png'
+    )
+
+    expect(paths.dir).toEqual({
+      baseline: 'User/my-project/cypress-visual-screenshots/baseline',
+      comparison: 'User/my-project/cypress-visual-screenshots/comparison',
+      diff: 'User/my-project/cypress-visual-screenshots/diff',
+    })
+
+    expect(paths.reportDir).toBe('User/my-project/cypress-visual-report')
+
+    expect(paths.report('test')).toBe(
+      'User/my-project/cypress-visual-report/cypress-visual-reporttest.html'
+    )
+  })
+
+  it('should return custom folder structure', () => {
+    processCwd.mockReturnValue('User/my-project/')
+
+    const paths = new Paths()
+    paths.rootDir = 'visual-test/custom-folder-name'
+
+    expect(paths.image.baseline('test')).toBe(
+      'User/my-project/visual-test/custom-folder-name/cypress-visual-screenshots/baseline/test.png'
+    )
+    expect(paths.image.comparison('test')).toBe(
+      'User/my-project/visual-test/custom-folder-name/cypress-visual-screenshots/comparison/test.png'
+    )
+    expect(paths.image.diff('test')).toBe(
+      'User/my-project/visual-test/custom-folder-name/cypress-visual-screenshots/diff/test.png'
+    )
+
+    expect(paths.dir).toEqual({
+      baseline:
+        'User/my-project/visual-test/custom-folder-name/cypress-visual-screenshots/baseline',
+      comparison:
+        'User/my-project/visual-test/custom-folder-name/cypress-visual-screenshots/comparison',
+      diff:
+        'User/my-project/visual-test/custom-folder-name/cypress-visual-screenshots/diff',
+    })
+
+    expect(paths.reportDir).toBe(
+      'User/my-project/visual-test/custom-folder-name/cypress-visual-report'
+    )
+
+    expect(paths.report('test')).toBe(
+      'User/my-project/visual-test/custom-folder-name/cypress-visual-report/cypress-visual-reporttest.html'
+    )
+  })
+})

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -107,7 +107,8 @@ async function compareSnapshotsPlugin(args) {
   return percentage
 }
 
-const getCompareSnapshotsPlugin = (on, config) => {
+const getCompareSnapshotsPlugin = (on, config, { rootDir = '' } = {}) => {
+  paths.rootDir = rootDir
   // Create folder structure
   setupFolders()
 


### PR DESCRIPTION
This is an attempt to fix hardcoded test folder, issue #9 #137 

This configuration is optional, shouldn't break current version.

I deliberately pass a third configuration option object to `getCompareSnapshotsPlugin`. I think there are a few benefits:
- scalable: There are more custom configurations that users could pass in later on that I could potentially see now, such as failureThreshold and retryOptions. At the moment, these two options can only be passed in at command level. It would be nice if we could have global configurations at plugin level that act more like defaults or fallbacks, so we don't have to pass them in for every command. (This will be in future pull requests)
- encapsulated: I could actually ask users to define `rootDir` under their e2e folder, then access via cypress config object. Although it might save us an extra function parameter for `getCompareSnapshotsPlugin`, it will be less explicit as to what config is for our own plugin and what isn't