### PR TITLE
fix: creating report if taking pictures with nested folders

### DIFF
--- a/src/reporter/__snapshots__/reporter.test.js.snap
+++ b/src/reporter/__snapshots__/reporter.test.js.snap
@@ -898,6 +898,7 @@ exports[`Reporter create report should create html template 1`] = `
             familyLine.line.forEach((memberName, index) => {
               const id = familyLine.getId(index)
               if (map[id]) return
+              if (!id) return
 
               map[id] = {
                 status: item.status,

--- a/src/reporter/template.hbs
+++ b/src/reporter/template.hbs
@@ -895,6 +895,7 @@
             familyLine.line.forEach((memberName, index) => {
               const id = familyLine.getId(index)
               if (map[id]) return
+              if (!id) return
 
               map[id] = {
                 status: item.status,


### PR DESCRIPTION
Error creating report if taking pictures with nested folders.
Example: cypress-visual-screenshots/comparison/folder-1/folder-2/image.png
![image](https://github.com/uktrade/cypress-image-diff/assets/46701856/24778a78-a95f-466e-a972-0e2b53399983)
