### PR TITLE
fix: Remove unexpected '-' in nested folder screenshot names

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -20,7 +20,7 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
       recurseOptions = userConfig.RETRY_OPTIONS
     ) => {
       const specName = Cypress.spec.name
-      const testName = `${specName.replace('.js', '')}-${name}`
+      const testName = `${specName.replace('.js', '')}${/^\//.test(name) ? name : '-' + name}`
 
       const defaultRecurseOptions = {
         limit: 1,

--- a/src/command.js
+++ b/src/command.js
@@ -20,7 +20,7 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
       recurseOptions = userConfig.RETRY_OPTIONS
     ) => {
       const specName = Cypress.spec.name
-      const testName = `${specName.replace('.js', '')}${/^\//.test(name) ? name : '-' + name}`
+      const testName = `${specName.replace('.js', '')}${/^\//.test(name) ? '' : '-'}${name}`
 
       const defaultRecurseOptions = {
         limit: 1,


### PR DESCRIPTION
fixes [https://github.com/uktrade/cypress-image-diff/pull/96#issuecomment-1215300863](url)