### PR TITLE
Feat: add an option to generate custom html report

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Currently supported values in the custom config file:
 - COMPARISON_OPTIONS: custom options passed to pixelmatch, see [pixelmatch options](https://github.com/mapbox/pixelmatch#api), default to `{ threshold: 0.1 }`. Please note that the `COMPARISON_OPTIONS.threshold` is different from the `FAILURE_THRESHOLD` above:
   - `COMPARISON_OPTIONS.threshold`: is the failure threshold for every pixel comparision
   - `FAILURE_THRESHOLD`: is the failure threshold for the whole comparision
-- HTML_REPORTER: this function allows you to build your own custom report with `testResults` argument, see [an example here](./docs/Reporting.md#reporting)
+- JSON_REPORT: 
+  - FILENAME: custom name for the json report file, default to `report_[datetime].json` in which `[datetime]` will be replaced with a timestamp. (ie. `report_29-08-2023_233219.json`)
+  - OVERWRITE: set to false if you don't want to overwrite existing report files, default to true. If a duplicate filename is found, the report will be saved with a counter digit added to the filename. (ie.`custom_report_name_1.json`)
 
 > **Note**: In order to make this custom config values effective, remember to return `getCompareSnapshotsPlugin` instance inside function `setupNodeEvents`:
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Currently supported values in the custom config file:
 - COMPARISON_OPTIONS: custom options passed to pixelmatch, see [pixelmatch options](https://github.com/mapbox/pixelmatch#api), default to `{ threshold: 0.1 }`. Please note that the `COMPARISON_OPTIONS.threshold` is different from the `FAILURE_THRESHOLD` above:
   - `COMPARISON_OPTIONS.threshold`: is the failure threshold for every pixel comparision
   - `FAILURE_THRESHOLD`: is the failure threshold for the whole comparision
+- HTML_REPORTER: this function allows you to build your own custom report with `testResults` argument, see [an example here](./docs/Reporting.md#reporting)
 
 > **Note**: In order to make this custom config values effective, remember to return `getCompareSnapshotsPlugin` instance inside function `setupNodeEvents`:
 

--- a/docs/Reporting.md
+++ b/docs/Reporting.md
@@ -22,21 +22,8 @@ The report will look something like:
 ![Cypress Image Diff Report](../report-example.png)
 
 ### Generate Custom HTML report
-If you want to generate your custom report, pass a builder function to `HTML_REPORTER` in [custom config file](https://github.com/kien-ht/cypress-image-diff#custom-config-file). In the below example, a file named `example.json` will be generated in the current directory after all the tests are run:
-```
-const fs = require('fs-extra')
 
-const config = {
-  ROOT_DIR: '',
-  HTML_REPORTER: (testResults) => {
-    fs.writeFile('./example.json', JSON.stringify(testResults, null, 2), (err) => {
-      console.log(err)
-    })
-  },
-}
-
-module.exports = config
-```
+If you want to generate your custom report, generate a report json file by passing `JSON_REPORT` in the [custom config file](../README.md#custom-config-file), and build your own HTML file from this json. 
 
 See [example.json](./report-example.json)
 

--- a/docs/Reporting.md
+++ b/docs/Reporting.md
@@ -6,6 +6,7 @@ Baseline, comparison and diff images will only be added to the report for failin
 
 ## Cypress support index
 
+### Generate default HTML report
 Add the following after hook
 
 ```js
@@ -19,6 +20,25 @@ after(() => {
 The report will look something like:
 
 ![Cypress Image Diff Report](../report-example.png)
+
+### Generate Custom HTML report
+If you want to generate your custom report, pass a builder function to `HTML_REPORTER` in [custom config file](https://github.com/kien-ht/cypress-image-diff#custom-config-file). In the below example, a file named `example.json` will be generated in the current directory after all the tests are run:
+```
+const fs = require('fs-extra')
+
+const config = {
+  ROOT_DIR: '',
+  HTML_REPORTER: (testResults) => {
+    fs.writeFile('./example.json', JSON.stringify(testResults, null, 2), (err) => {
+      console.log(err)
+    })
+  },
+}
+
+module.exports = config
+```
+
+See [example.json](./report-example.json)
 
 ## Folder structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cypress-recurse": "^1.13.1",
         "fs-extra": "^9.0.1",
         "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
         "pixelmatch": "^5.1.0",
         "pngjs": "^3.4.0"
       },
@@ -11533,8 +11534,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -27081,8 +27081,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.capitalize": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cypress-recurse": "^1.13.1",
     "fs-extra": "^9.0.1",
     "handlebars": "^4.7.7",
+    "lodash": "^4.17.21",
     "pixelmatch": "^5.1.0",
     "pngjs": "^3.4.0"
   },

--- a/report-example.json
+++ b/report-example.json
@@ -1,98 +1,98 @@
 {
-    "total": 6,
-    "totalPassed": 3,
-    "totalFailed": 3,
-    "totalSuites": 3,
-    "suites": [
-      {
-        "name": "image-diff.cy.js",
-        "path": "cypress/specs/image-diff.cy.js",
-        "tests": [
-          {
-            "status": "fail",
-            "name": "image-diff.cy-wholePage",
-            "percentage": 0.0900966398590363,
-            "failureThreshold": 0,
-            "specPath": "cypress/specs/image-diff.cy.js",
-            "specFilename": "image-diff.cy.js",
-            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-wholePage.png",
-            "diffPath": "cypress-visual-screenshots/diff/image-diff.cy-wholePage.png",
-            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-wholePage.png"
-          },
-          {
-            "status": "pass",
-            "name": "image-diff.cy-wholePageThreshold",
-            "percentage": 0.0900966398590363,
-            "failureThreshold": 0.2,
-            "specPath": "cypress/specs/image-diff.cy.js",
-            "specFilename": "image-diff.cy.js",
-            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-wholePageThreshold.png",
-            "diffPath": "",
-            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-wholePageThreshold.png"
-          },
-          {
-            "status": "pass",
-            "name": "image-diff.cy-element",
-            "percentage": 0,
-            "failureThreshold": 0,
-            "specPath": "cypress/specs/image-diff.cy.js",
-            "specFilename": "image-diff.cy.js",
-            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-element.png",
-            "diffPath": "",
-            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-element.png"
-          },
-          {
-            "status": "fail",
-            "name": "image-diff.cy-hideElement",
-            "percentage": 0.0900966398590363,
-            "failureThreshold": 0,
-            "specPath": "cypress/specs/image-diff.cy.js",
-            "specFilename": "image-diff.cy.js",
-            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-hideElement.png",
-            "diffPath": "cypress-visual-screenshots/diff/image-diff.cy-hideElement.png",
-            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-hideElement.png"
-          }
-        ]
-      },
-      {
-        "name": "retry.cy.js",
-        "path": "cypress/specs/retry.cy.js",
-        "tests": [
-          {
-            "status": "pass",
-            "name": "retry.cy-retry",
-            "percentage": 0,
-            "failureThreshold": 0,
-            "specPath": "cypress/specs/retry.cy.js",
-            "specFilename": "retry.cy.js",
-            "baselinePath": "cypress-visual-screenshots/baseline/retry.cy-retry.png",
-            "diffPath": "",
-            "comparisonPath": "cypress-visual-screenshots/comparison/retry.cy-retry.png"
-          }
-        ]
-      },
-      {
-        "name": "folder-structure.cy.js",
-        "path": "cypress/specs/folder-structure-test/folder-structure.cy.js",
-        "tests": [
-          {
-            "status": "fail",
-            "name": "folder-structure.cy-wholePage",
-            "percentage": 0.0900966398590363,
-            "failureThreshold": 0,
-            "specPath": "cypress/specs/folder-structure-test/folder-structure.cy.js",
-            "specFilename": "folder-structure.cy.js",
-            "baselinePath": "cypress-visual-screenshots/baseline/folder-structure.cy-wholePage.png",
-            "diffPath": "cypress-visual-screenshots/diff/folder-structure.cy-wholePage.png",
-            "comparisonPath": "cypress-visual-screenshots/comparison/folder-structure.cy-wholePage.png"
-          }
-        ]
-      }
-    ],
-    "startedAt": "2023-08-25T09:53:41.477Z",
-    "endedAt": "2023-08-25T09:54:00.875Z",
-    "duration": 15318,
-    "browserName": "chrome",
-    "browserVersion": "116.0.5845.110",
-    "cypressVersion": "10.8.0"
+  "total": 6,
+  "totalPassed": 3,
+  "totalFailed": 3,
+  "totalSuites": 3,
+  "suites": [
+    {
+      "name": "image-diff.cy.js",
+      "path": "cypress/specs/image-diff.cy.js",
+      "tests": [
+        {
+          "status": "fail",
+          "name": "image-diff.cy-wholePage",
+          "percentage": 0.0900966398590363,
+          "failureThreshold": 0,
+          "specPath": "cypress/specs/image-diff.cy.js",
+          "specFilename": "image-diff.cy.js",
+          "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-wholePage.png",
+          "diffPath": "cypress-visual-screenshots/diff/image-diff.cy-wholePage.png",
+          "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-wholePage.png"
+        },
+        {
+          "status": "pass",
+          "name": "image-diff.cy-wholePageThreshold",
+          "percentage": 0.0900966398590363,
+          "failureThreshold": 0.2,
+          "specPath": "cypress/specs/image-diff.cy.js",
+          "specFilename": "image-diff.cy.js",
+          "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-wholePageThreshold.png",
+          "diffPath": "",
+          "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-wholePageThreshold.png"
+        },
+        {
+          "status": "pass",
+          "name": "image-diff.cy-element",
+          "percentage": 0,
+          "failureThreshold": 0,
+          "specPath": "cypress/specs/image-diff.cy.js",
+          "specFilename": "image-diff.cy.js",
+          "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-element.png",
+          "diffPath": "",
+          "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-element.png"
+        },
+        {
+          "status": "fail",
+          "name": "image-diff.cy-hideElement",
+          "percentage": 0.0900966398590363,
+          "failureThreshold": 0,
+          "specPath": "cypress/specs/image-diff.cy.js",
+          "specFilename": "image-diff.cy.js",
+          "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-hideElement.png",
+          "diffPath": "cypress-visual-screenshots/diff/image-diff.cy-hideElement.png",
+          "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-hideElement.png"
+        }
+      ]
+    },
+    {
+      "name": "retry.cy.js",
+      "path": "cypress/specs/retry.cy.js",
+      "tests": [
+        {
+          "status": "pass",
+          "name": "retry.cy-retry",
+          "percentage": 0,
+          "failureThreshold": 0,
+          "specPath": "cypress/specs/retry.cy.js",
+          "specFilename": "retry.cy.js",
+          "baselinePath": "cypress-visual-screenshots/baseline/retry.cy-retry.png",
+          "diffPath": "",
+          "comparisonPath": "cypress-visual-screenshots/comparison/retry.cy-retry.png"
+        }
+      ]
+    },
+    {
+      "name": "folder-structure.cy.js",
+      "path": "cypress/specs/folder-structure-test/folder-structure.cy.js",
+      "tests": [
+        {
+          "status": "fail",
+          "name": "folder-structure.cy-wholePage",
+          "percentage": 0.0900966398590363,
+          "failureThreshold": 0,
+          "specPath": "cypress/specs/folder-structure-test/folder-structure.cy.js",
+          "specFilename": "folder-structure.cy.js",
+          "baselinePath": "cypress-visual-screenshots/baseline/folder-structure.cy-wholePage.png",
+          "diffPath": "cypress-visual-screenshots/diff/folder-structure.cy-wholePage.png",
+          "comparisonPath": "cypress-visual-screenshots/comparison/folder-structure.cy-wholePage.png"
+        }
+      ]
+    }
+  ],
+  "startedAt": "2023-08-25T09:53:41.477Z",
+  "endedAt": "2023-08-25T09:54:00.875Z",
+  "duration": 15318,
+  "browserName": "chrome",
+  "browserVersion": "116.0.5845.110",
+  "cypressVersion": "10.8.0"
 }

--- a/report-example.json
+++ b/report-example.json
@@ -1,0 +1,98 @@
+{
+    "total": 6,
+    "totalPassed": 3,
+    "totalFailed": 3,
+    "totalSuites": 3,
+    "suites": [
+      {
+        "name": "image-diff.cy.js",
+        "path": "cypress/specs/image-diff.cy.js",
+        "tests": [
+          {
+            "status": "fail",
+            "name": "image-diff.cy-wholePage",
+            "percentage": 0.0900966398590363,
+            "failureThreshold": 0,
+            "specPath": "cypress/specs/image-diff.cy.js",
+            "specFilename": "image-diff.cy.js",
+            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-wholePage.png",
+            "diffPath": "cypress-visual-screenshots/diff/image-diff.cy-wholePage.png",
+            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-wholePage.png"
+          },
+          {
+            "status": "pass",
+            "name": "image-diff.cy-wholePageThreshold",
+            "percentage": 0.0900966398590363,
+            "failureThreshold": 0.2,
+            "specPath": "cypress/specs/image-diff.cy.js",
+            "specFilename": "image-diff.cy.js",
+            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-wholePageThreshold.png",
+            "diffPath": "",
+            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-wholePageThreshold.png"
+          },
+          {
+            "status": "pass",
+            "name": "image-diff.cy-element",
+            "percentage": 0,
+            "failureThreshold": 0,
+            "specPath": "cypress/specs/image-diff.cy.js",
+            "specFilename": "image-diff.cy.js",
+            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-element.png",
+            "diffPath": "",
+            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-element.png"
+          },
+          {
+            "status": "fail",
+            "name": "image-diff.cy-hideElement",
+            "percentage": 0.0900966398590363,
+            "failureThreshold": 0,
+            "specPath": "cypress/specs/image-diff.cy.js",
+            "specFilename": "image-diff.cy.js",
+            "baselinePath": "cypress-visual-screenshots/baseline/image-diff.cy-hideElement.png",
+            "diffPath": "cypress-visual-screenshots/diff/image-diff.cy-hideElement.png",
+            "comparisonPath": "cypress-visual-screenshots/comparison/image-diff.cy-hideElement.png"
+          }
+        ]
+      },
+      {
+        "name": "retry.cy.js",
+        "path": "cypress/specs/retry.cy.js",
+        "tests": [
+          {
+            "status": "pass",
+            "name": "retry.cy-retry",
+            "percentage": 0,
+            "failureThreshold": 0,
+            "specPath": "cypress/specs/retry.cy.js",
+            "specFilename": "retry.cy.js",
+            "baselinePath": "cypress-visual-screenshots/baseline/retry.cy-retry.png",
+            "diffPath": "",
+            "comparisonPath": "cypress-visual-screenshots/comparison/retry.cy-retry.png"
+          }
+        ]
+      },
+      {
+        "name": "folder-structure.cy.js",
+        "path": "cypress/specs/folder-structure-test/folder-structure.cy.js",
+        "tests": [
+          {
+            "status": "fail",
+            "name": "folder-structure.cy-wholePage",
+            "percentage": 0.0900966398590363,
+            "failureThreshold": 0,
+            "specPath": "cypress/specs/folder-structure-test/folder-structure.cy.js",
+            "specFilename": "folder-structure.cy.js",
+            "baselinePath": "cypress-visual-screenshots/baseline/folder-structure.cy-wholePage.png",
+            "diffPath": "cypress-visual-screenshots/diff/folder-structure.cy-wholePage.png",
+            "comparisonPath": "cypress-visual-screenshots/comparison/folder-structure.cy-wholePage.png"
+          }
+        ]
+      }
+    ],
+    "startedAt": "2023-08-25T09:53:41.477Z",
+    "endedAt": "2023-08-25T09:54:00.875Z",
+    "duration": 15318,
+    "browserName": "chrome",
+    "browserVersion": "116.0.5845.110",
+    "cypressVersion": "10.8.0"
+}

--- a/src/command.js
+++ b/src/command.js
@@ -51,7 +51,9 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
           const options = {
             testName,
             testThreshold,
-            failOnMissingBaseline: userConfig.FAIL_ON_MISSING_BASELINE
+            failOnMissingBaseline: userConfig.FAIL_ON_MISSING_BASELINE,
+            specFilename: Cypress.spec.name,
+            specPath: Cypress.spec.relative,
           }
           
           return cy.task('compareSnapshotsPlugin', options)
@@ -70,12 +72,6 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
     }
     return undefined
   })
-
-  if (userConfig.GENERATE_HTML_REPORTER) {
-    after(() => {
-      cy.task('generateHtmlReport')
-    })
-  }
 }
 
 module.exports = compareSnapshotCommand

--- a/src/command.js
+++ b/src/command.js
@@ -70,6 +70,12 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
     }
     return undefined
   })
+
+  if (userConfig.GENERATE_HTML_REPORTER) {
+    after(() => {
+      cy.task('generateHtmlReport')
+    })
+  }
 }
 
 module.exports = compareSnapshotCommand

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,9 @@ const DEFAULT_CONFIG = {
   FAILURE_THRESHOLD: 0,
   RETRY_OPTIONS: {},
   FAIL_ON_MISSING_BASELINE: false,
-  COMPARISON_OPTIONS: { threshold: 0.1 }
+  COMPARISON_OPTIONS: { threshold: 0.1 },
+  GENERATE_HTML_REPORTER: false,
+  CUSTOM_HTML_REPORTER: null
 }
 
 export const userConfig = { ...DEFAULT_CONFIG, ...getUserConfigFile() }

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import merge from 'lodash/merge'
 
 function getUserConfigFile() {
   try {
@@ -15,10 +16,13 @@ const DEFAULT_CONFIG = {
   RETRY_OPTIONS: {},
   FAIL_ON_MISSING_BASELINE: false,
   COMPARISON_OPTIONS: { threshold: 0.1 },
-  HTML_REPORTER: undefined
+  JSON_REPORT: {
+    FILENAME: '',
+    OVERWRITE: true
+  }
 }
 
-export const userConfig = { ...DEFAULT_CONFIG, ...getUserConfigFile() }
+export const userConfig = merge(DEFAULT_CONFIG, getUserConfigFile())
 
 export class Paths {
   constructor() {

--- a/src/config.js
+++ b/src/config.js
@@ -15,8 +15,7 @@ const DEFAULT_CONFIG = {
   RETRY_OPTIONS: {},
   FAIL_ON_MISSING_BASELINE: false,
   COMPARISON_OPTIONS: { threshold: 0.1 },
-  GENERATE_HTML_REPORTER: false,
-  CUSTOM_HTML_REPORTER: null
+  HTML_REPORTER: undefined
 }
 
 export const userConfig = { ...DEFAULT_CONFIG, ...getUserConfigFile() }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -224,9 +224,9 @@ const getCompareSnapshotsPlugin = (on, config) => {
     }
   })
 
-  on('after:run', (results) => {
+  on('after:run', async (results) => {
     if (userConfig.JSON_REPORT) {
-      generateJsonReport(results)
+      await generateJsonReport(results)
     }
   })
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -31,6 +31,17 @@ const generateReport = (instance = '') => {
   return true
 }
 
+const generateHtmlReport = () => {
+  if (testStatuses.length > 0) {
+    if (typeof userConfig.CUSTOM_HTML_REPORTER === 'function') {
+      userConfig.CUSTOM_HTML_REPORTER(testStatuses)
+    } else {
+      createReport({ tests: JSON.stringify(testStatuses), instance: '' })
+    }
+  }
+  return true
+}
+
 const deleteReport = args => {
   testStatuses = testStatuses.filter(testStatus => testStatus.name !== args.testName)
 
@@ -176,6 +187,7 @@ const getCompareSnapshotsPlugin = (on, config) => {
     copyScreenshot,
     deleteScreenshot,
     generateReport,
+    generateHtmlReport,
     deleteReport,
   })
 

--- a/src/reporter/test-status.js
+++ b/src/reporter/test-status.js
@@ -1,9 +1,14 @@
 class TestStatus {
-  constructor({ status, name, percentage, failureThreshold }) {
+  constructor({ status, name, percentage, failureThreshold, specPath, specFilename, baselinePath, diffPath, comparisonPath }) {
     this.status = status ? 'pass' : 'fail'
     this.name = name
     this.percentage = percentage
     this.failureThreshold = failureThreshold
+    this.specPath = specPath
+    this.specFilename = specFilename
+    this.baselinePath = baselinePath
+    this.diffPath = diffPath
+    this.comparisonPath = comparisonPath
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import path from 'path'
 import { PNG } from 'pngjs'
 
 const createDir = dirs => {
@@ -72,4 +73,9 @@ const adjustCanvas = async (image, width, height) => {
   return imageAdjustedCanvas
 }
 
-export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile }
+const getRelativePathFromCwd = (dir) => {
+  const relative = path.relative(process.cwd(), dir)
+  return fs.existsSync(relative) ? relative : ''
+}
+
+export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile, getRelativePathFromCwd }

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,4 +78,24 @@ const getRelativePathFromCwd = (dir) => {
   return fs.existsSync(relative) ? relative : ''
 }
 
-export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile, getRelativePathFromCwd }
+const getCleanDate = (date) => {
+  const source = date ? new Date(date) : new Date()
+  return source
+    .toLocaleString('en-GB')
+    .replace(/(,\s*)|,|\s+/g, '_')
+    .replace(/\\|\//g, '-')
+    .replace(/:/g, '')
+}
+
+const writeFileIncrement = async (name, data, increment = 1) => {
+  const filename = `${path.basename(name, path.extname(name))}${
+    increment >= 2 ? `_${increment}` : ''
+  }${path.extname(name)}`
+
+  const absolutePath = path.join(path.dirname(name), filename)
+  if (fs.existsSync(absolutePath) === false) return fs.writeFile(absolutePath, data)
+
+  return writeFileIncrement(name, data, increment + 1)
+}
+
+export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile, getRelativePathFromCwd, getCleanDate, writeFileIncrement }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, emptyDirSync, readdirSync, moveSync, copySync } from 'fs-extra'
-import { createDir, cleanDir, renameAndMoveFile, renameAndCopyFile } from './utils'
+import { existsSync, mkdirSync, emptyDirSync, readdirSync, moveSync, copySync, writeFile } from 'fs-extra'
+import { createDir, cleanDir, renameAndMoveFile, renameAndCopyFile, getRelativePathFromCwd, getCleanDate, writeFileIncrement } from './utils'
 
 jest.mock('fs-extra', () => ({
   ...jest.requireActual('fs-extra'),
@@ -9,6 +9,7 @@ jest.mock('fs-extra', () => ({
   readdirSync: jest.fn(),
   moveSync: jest.fn(),
   copySync: jest.fn(),
+  writeFile: jest.fn(),
 }))
 
 describe('Utils', () => {
@@ -70,6 +71,64 @@ describe('Utils', () => {
       renameAndCopyFile(sampleFiles[0], sampleFiles[1])
       expect(copySync).toHaveBeenCalledTimes(1)
       expect(copySync).toBeCalledWith(sampleFiles[0], sampleFiles[1], {"overwrite": true})
+    })
+  })
+
+  describe('Get relative path from the current working directory', () => {
+    const processCwd = jest.spyOn(process, 'cwd')
+    const fakeCwd = 'User/my-project/'
+
+    beforeEach(() => {
+      processCwd.mockReturnValue(fakeCwd)
+    })
+
+    it('should return empty string when path doesn\'t exist', () => {
+      existsSync.mockReturnValue(false)
+      
+      const relativePath = getRelativePathFromCwd('User/my-project/cypress/screenshot.png')
+      expect(relativePath).toBe('')
+    })
+  
+    it('should return a relative path when given path exists', () => {
+      existsSync.mockReturnValue(true)
+
+      const relativePath = getRelativePathFromCwd('User/my-project/cypress/screenshot.png')
+      expect(relativePath).toBe('cypress/screenshot.png')
+    })
+  })
+
+  describe('Get clean date string', () => {
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('should return a clean date string', () => {
+      const fakeDate = '01/09/2023, 23:22:48'
+      jest.spyOn(Date.prototype, 'toLocaleString').mockReturnValue(fakeDate)
+
+      expect(getCleanDate()).toBe('01-09-2023_232248')
+    })
+  })
+
+  describe('Write incremented filename', () => {
+    const filename = 'User/my-project/report.json'
+    const filenameIncremented = 'User/my-project/report_2.json'
+    const fakeData = '{\n  "name": "test"\n}'
+
+    it('should create a new file with given name when no filename found', () => {
+      existsSync.mockReturnValue(false)
+
+      writeFileIncrement(filename, fakeData)
+      expect(writeFile).toHaveBeenCalledTimes(1)
+      expect(writeFile).toBeCalledWith(filename, fakeData)
+    })
+
+    it('should increment filename when it already exists', () => {
+      existsSync.mockReturnValueOnce(true).mockReturnValueOnce(false)
+
+      writeFileIncrement(filename, fakeData)
+      expect(writeFile).toHaveBeenCalledTimes(1)
+      expect(writeFile).toBeCalledWith(filenameIncremented, fakeData)
     })
   })
 })


### PR DESCRIPTION
There are two main reasons I want to implement this feature:
- Decouple our current default HTML report from this plugin's core function and move it into its own repository: There is more room for us to grow there. I've got a few feature ideas in mind that I'll be working on in the near future, such as a cool side-by-side comparison, updating one or more snapshots with a click (#120, #107 ), re-running a particular test suit, and clicking a test suit to view its original spec file in the default IDE. These features would be much easier to develop and maintain with a front-end framework like Vue or React and a node server. Hence, it should deserve its own repository. Plus, it doesn't benefit users who don't need a report but burdens the plugin's size.
- Users can have a custom report of their choice if they want.

For the time being, I'm adding this feature to make custom reports in the hope of fixing this issue #160 and #136. The current default HTML report will still be functional just fine, but will be relocated in the near future.