### PR TITLE
feat: show avg fail percentage each item header

### DIFF
--- a/src/reporter/__snapshots__/reporter.test.js.snap
+++ b/src/reporter/__snapshots__/reporter.test.js.snap
@@ -232,8 +232,12 @@ exports[`Reporter create report should create html template 1`] = `
       .collapse-item.branch[data-current-filter='total'] [data-filter-type='pass'],
       .collapse-item.branch[data-current-filter='total'] [data-filter-type='fail'],
       .collapse-item.branch[data-current-filter='pass'] [data-filter-type='pass'],
-      .collapse-item.branch[data-current-filter='fail'] [data-filter-type='fail'] {
+      .collapse-item.branch[data-current-filter='fail'] [data-filter-type='fail'],
+      .collapse-item.branch[data-current-filter='total'] [data-filter-type='failPercentage'] {
         display: flex;
+      }
+      .collapse-item.branch[data-current-filter='total'] [data-filter-type='failPercentage'] .icon {
+        background-size: 16px;
       }
       @keyframes fadeIn {
         from { opacity: 0 }
@@ -588,6 +592,10 @@ exports[`Reporter create report should create html template 1`] = `
               <div class=\\"icon close-icon\\"></div>
               <b>$__fails__</b>
             </div>
+            <div class=\\"icon-container\\" data-filter-type=\\"failPercentage\\">
+              <div class=\\"icon frown-face-icon\\"></div>
+              <b>$__failPercentage__%</b>
+            </div>
           </div>
 
           <div class=\\"collapse-item__content\\"></div>
@@ -853,11 +861,12 @@ exports[`Reporter create report should create html template 1`] = `
           return leaf
         },
 
-        createBranch({ title, passes, fails, children, id }) {
+        createBranch({ title, passes, fails,failPercentage, children, id }) {
           const branch = DOMBuilder.cloneTemplate('branch-template', {
             title,
             passes,
             fails,
+            failPercentage,
             id
           })
           DOMBuilder.insertChildren({
@@ -920,7 +929,7 @@ exports[`Reporter create report should create html template 1`] = `
           return Object.values(itemMap).map((v) => v)
         }
 
-        countTotal(children, status) {
+        countTotal(children, status, percentage) {
           return {
             passes: children.length
               ? children.reduce((acc, i) => acc + i.total.passes, 0)
@@ -931,7 +940,10 @@ exports[`Reporter create report should create html template 1`] = `
               ? children.reduce((acc, i) => acc + i.total.fails, 0)
               : status === ITEM_STATUS.FAIL
               ? 1
-              : 0
+              : 0,
+            failPercentage: children.length
+              ? children.reduce((acc, i) => (acc + i.total.failPercentage)/2, 0)
+              : percentage
           }
         }
 
@@ -947,7 +959,7 @@ exports[`Reporter create report should create html template 1`] = `
                 title,
                 children,
                 ...(children.length ? {} : { status, percentage, failureThreshold }),
-                total: this.countTotal(children, status),
+                total: this.countTotal(children, status, percentage),
               }
             })
         }
@@ -962,6 +974,7 @@ exports[`Reporter create report should create html template 1`] = `
               title: item.title,
               passes: item.total.passes,
               fails: item.total.fails,
+              failPercentage: (item.total.failPercentage * 100).toFixed(1),
               percentage: (item.percentage * 100).toFixed(1),
               failureThreshold: (item.failureThreshold * 100).toFixed(1),
               id: item.id,

--- a/src/reporter/template.hbs
+++ b/src/reporter/template.hbs
@@ -229,8 +229,12 @@
       .collapse-item.branch[data-current-filter='total'] [data-filter-type='pass'],
       .collapse-item.branch[data-current-filter='total'] [data-filter-type='fail'],
       .collapse-item.branch[data-current-filter='pass'] [data-filter-type='pass'],
-      .collapse-item.branch[data-current-filter='fail'] [data-filter-type='fail'] {
+      .collapse-item.branch[data-current-filter='fail'] [data-filter-type='fail'],
+      .collapse-item.branch[data-current-filter='total'] [data-filter-type='failPercentage'] {
         display: flex;
+      }
+      .collapse-item.branch[data-current-filter='total'] [data-filter-type='failPercentage'] .icon {
+        background-size: 16px;
       }
       @keyframes fadeIn {
         from { opacity: 0 }
@@ -585,6 +589,10 @@
               <div class="icon close-icon"></div>
               <b>$__fails__</b>
             </div>
+            <div class="icon-container" data-filter-type="failPercentage">
+              <div class="icon frown-face-icon"></div>
+              <b>$__failPercentage__%</b>
+            </div>
           </div>
 
           <div class="collapse-item__content"></div>
@@ -850,11 +858,12 @@
           return leaf
         },
 
-        createBranch({ title, passes, fails, children, id }) {
+        createBranch({ title, passes, fails,failPercentage, children, id }) {
           const branch = DOMBuilder.cloneTemplate('branch-template', {
             title,
             passes,
             fails,
+            failPercentage,
             id
           })
           DOMBuilder.insertChildren({
@@ -917,7 +926,7 @@
           return Object.values(itemMap).map((v) => v)
         }
 
-        countTotal(children, status) {
+        countTotal(children, status, percentage) {
           return {
             passes: children.length
               ? children.reduce((acc, i) => acc + i.total.passes, 0)
@@ -928,7 +937,10 @@
               ? children.reduce((acc, i) => acc + i.total.fails, 0)
               : status === ITEM_STATUS.FAIL
               ? 1
-              : 0
+              : 0,
+            failPercentage: children.length
+              ? children.reduce((acc, i) => (acc + i.total.failPercentage)/2, 0)
+              : percentage
           }
         }
 
@@ -944,7 +956,7 @@
                 title,
                 children,
                 ...(children.length ? {} : { status, percentage, failureThreshold }),
-                total: this.countTotal(children, status),
+                total: this.countTotal(children, status, percentage),
               }
             })
         }
@@ -959,6 +971,7 @@
               title: item.title,
               passes: item.total.passes,
               fails: item.total.fails,
+              failPercentage: (item.total.failPercentage * 100).toFixed(1),
               percentage: (item.percentage * 100).toFixed(1),
               failureThreshold: (item.failureThreshold * 100).toFixed(1),
               id: item.id,


### PR DESCRIPTION
![image](https://github.com/uktrade/cypress-image-diff/assets/46701856/37e66770-0a0a-4b2d-a772-385464f70559)

I added the feature to display the average percentage of error for each case.

I have too many test cases to keep track of details. I only care about the code team fixing any code that reduces the failure rate. To me, it is a KPI that needs to be changed every time a successful test case is fixed.

You can further appreciate its usefulness for everyone.