### PR TITLE
fix: set default user config when cypressImageDiff undefined

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,7 +1,8 @@
 import { recurse } from 'cypress-recurse';
+import DEFAULT_CONFIG from './config.default'
 
 const compareSnapshotCommand = defaultScreenshotOptions => {
-  const userConfig = Cypress.env('cypressImageDiff')
+  const userConfig = Cypress.env('cypressImageDiff') || DEFAULT_CONFIG
 
   const height = Cypress.config('viewportHeight') || 1440
   const width = Cypress.config('viewportWidth') || 1980

--- a/src/config.default.js
+++ b/src/config.default.js
@@ -1,0 +1,11 @@
+export default {
+  ROOT_DIR: '',
+  FAILURE_THRESHOLD: 0,
+  RETRY_OPTIONS: {},
+  FAIL_ON_MISSING_BASELINE: false,
+  COMPARISON_OPTIONS: { threshold: 0.1 },
+  JSON_REPORT: {
+    FILENAME: '',
+    OVERWRITE: true,
+  },
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 import path from 'path'
 import merge from 'lodash/merge'
+import DEFAULT_CONFIG from './config.default'
 
 function getUserConfigFile() {
   try {
@@ -7,18 +8,6 @@ function getUserConfigFile() {
     return require(path.join(process.cwd(), 'cypress-image-diff.config'))
   } catch (err) {
     return {}
-  }
-}
-
-const DEFAULT_CONFIG = {
-  ROOT_DIR: '',
-  FAILURE_THRESHOLD: 0,
-  RETRY_OPTIONS: {},
-  FAIL_ON_MISSING_BASELINE: false,
-  COMPARISON_OPTIONS: { threshold: 0.1 },
-  JSON_REPORT: {
-    FILENAME: '',
-    OVERWRITE: true
   }
 }
 


### PR DESCRIPTION
Fixes #172. For users who want to use the default configuration and not return `getCompareSnapshotsPlugin` instance inside the function `setupNodeEvents`