### PR TITLE
feat: replace .ts file extension

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -21,7 +21,7 @@ const compareSnapshotCommand = defaultScreenshotOptions => {
       recurseOptions = userConfig.RETRY_OPTIONS
     ) => {
       const specName = Cypress.spec.name
-      const testName = `${specName.replace('.js', '')}${/^\//.test(name) ? '' : '-'}${name}`
+      const testName = `${specName.replace('.js', '').replace('.ts', '')}${/^\//.test(name) ? '' : '-'}${name}`
 
       const defaultRecurseOptions = {
         limit: 1,


### PR DESCRIPTION
For tests using .ts files, when get screenshots, the file name will be `[name].ts`. This is not consistent with .js files