### PR TITLE
fix: add an escape hatch for esm config file

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,14 @@
 import path from 'path'
 import merge from 'lodash/merge'
+import fs from 'fs-extra'
 import DEFAULT_CONFIG from './config.default'
 
 function getUserConfigFile() {
   try {
+    if (fs.existsSync(path.join(process.cwd(), 'cypress-image-diff.config.cjs'))) {
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      return require(path.join(process.cwd(), 'cypress-image-diff.config.cjs'))
+    }
     // eslint-disable-next-line import/no-dynamic-require, global-require
     return require(path.join(process.cwd(), 'cypress-image-diff.config'))
   } catch (err) {

--- a/types/plugin.d.ts
+++ b/types/plugin.d.ts
@@ -3,6 +3,6 @@
 declare function getCompareSnapshotsPlugin(
   on: Cypress.PluginEvents,
   config: Cypress.PluginConfigOptions,
-): void
+): Cypress.PluginConfigOptions
 
 export default getCompareSnapshotsPlugin;


### PR DESCRIPTION
This pull request fixes #192

CommonJS doesn't support importing ESM modules with `require` statements, and because our plugin is shipped as CommonJs, we fail to resolve the user config file `cypress-image-diff.config.js` in those projects that are ESM modules.

