### PR TITLE
fix: add explicit .js extension for project module exporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "exports": {
     "./command": {
       "types": "./types/command.d.ts",
-      "default": "./dist/command"
+      "default": "./dist/command.js"
     },
     "./plugin": {
       "types": "./types/plugin.d.ts",
-      "default": "./dist/plugin"
+      "default": "./dist/plugin.js"
     }
   },
   "files": ["dist", "types"],


### PR DESCRIPTION
fixes #194 