### PR TITLE
fix: add support fallback import for command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "cypress-image-diff-js",
   "version": "0.0.0",
   "description": "Visual regression testing tool with cypress",
+  "main": "./dist/command.js",
+  "types": "./types/command.d.ts",
   "exports": {
+    ".": {
+      "types": "./types/command.d.ts",
+      "default": "./dist/command.js"
+    },
     "./command": {
       "types": "./types/command.d.ts",
       "default": "./dist/command.js"


### PR DESCRIPTION
Fixes #198. Add support fallback import for command function for Cypress v12.17.3 and older

```
import getCompareSnapshotsPlugin from 'cypress-image-diff-js'
// is an alias for:
// import getCompareSnapshotsPlugin from 'cypress-image-diff-js/command'
```

```diff
For Cypress v12.17.3 and older:
- import getCompareSnapshotsPlugin from 'cypress-image-diff-js/command'
+ import getCompareSnapshotsPlugin from 'cypress-image-diff-js'
```
