### PR TITLE
fix: Catch comparison file load failure and trigger test failure

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -72,8 +72,12 @@ const getStatsComparisonAndPopulateDiffIfAny = async (args) => {
       ? { percentage: 1, testFailed: true }
       : { percentage: 0, testFailed: false }
   }
-
-  const comparisonImg = await parseImage(paths.image.comparison(args.testName))
+  let comparisonImg
+  try {
+    comparisonImg = await parseImage(paths.image.comparison(args.testName))
+  } catch (e) {
+    return { percentage: 1, testFailed: true }
+  }
   const diff = new PNG({
     width: Math.max(comparisonImg.width, baselineImg.width),
     height: Math.max(comparisonImg.height, baselineImg.height),


### PR DESCRIPTION
Catches error when comparison file isn't loaded. Issue explained in full here: https://github.com/uktrade/cypress-image-diff/issues/209

Could you please review? This issue is currently biting us at our organisation.