### PR TITLE
#208 fixes module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "./dist/command.js",
   "types": "./types/command.d.ts",
   "exports": {
+    "./dist/config.default": {
+      "default": "./dist/config.default.js"
+    },
     ".": {
       "types": "./types/command.d.ts",
       "default": "./dist/command.js"


### PR DESCRIPTION
Issue #208 

Fixes Error: 
Webpack Compilation Error
Module not found: Error: Package path ./dist/config.default is not exported from package /Users/XXX/work/visual_regression_testing/node_modules/cypress-image-diff-js (see exports field in /Users/XXX/work/visual_regression_testing/node_modules/cypress-image-diff-js/package.json)

