### PR TITLE
feat: add INLINE_ASSETS config option

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -63,6 +63,7 @@ const compareSnapshotCommand = () => {
             failOnMissingBaseline: userConfig.FAIL_ON_MISSING_BASELINE,
             specFilename: Cypress.spec.name,
             specPath: Cypress.spec.relative,
+            inlineAssets: userConfig.INLINE_ASSETS
           }
           
           return cy.task('compareSnapshotsPlugin', options)

--- a/src/config.default.js
+++ b/src/config.default.js
@@ -11,4 +11,5 @@ export default {
     OVERWRITE: true,
   },
   CYPRESS_SCREENSHOT_OPTIONS: {},
+  INLINE_ASSETS: false
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -12,7 +12,8 @@ import {
   renameAndMoveFile, renameAndCopyFile,
   getRelativePathFromCwd,
   getCleanDate,
-  writeFileIncrement
+  writeFileIncrement,
+  toBase64
 } from './utils'
 import paths, { userConfig } from './config'
 import TestStatus from './reporter/test-status'
@@ -119,7 +120,7 @@ async function compareSnapshotsPlugin(args) {
   const { percentage, testFailed } = await getStatsComparisonAndPopulateDiffIfAny(args)
 
   // Saving test status object to build report if task is triggered
-  testStatuses.push(new TestStatus({ 
+  let newTest = new TestStatus({ 
     status: !testFailed,
     name: args.testName,
     percentage,
@@ -128,8 +129,24 @@ async function compareSnapshotsPlugin(args) {
     specPath: args.specPath,
     baselinePath: getRelativePathFromCwd(paths.image.baseline(args.testName)),
     diffPath: getRelativePathFromCwd(paths.image.diff(args.testName)),
-    comparisonPath: getRelativePathFromCwd(paths.image.comparison(args.testName)),
-  }))
+    comparisonPath: getRelativePathFromCwd(paths.image.comparison(args.testName))
+  })
+
+  if (args.inlineAssets) {
+    const [baselineDataUrl, diffDataUrl, comparisonDataUrl] = await Promise.all([
+      toBase64(newTest.baselinePath),
+      toBase64(newTest.diffPath),
+      toBase64(newTest.comparisonPath),
+    ])
+    newTest = {
+      ...newTest,
+      baselineDataUrl,
+      diffDataUrl,
+      comparisonDataUrl
+    }
+  }
+
+  testStatuses.push(newTest)
 
   return percentage
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,4 +98,11 @@ const writeFileIncrement = async (name, data, increment = 1) => {
   return writeFileIncrement(name, data, increment + 1)
 }
 
-export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile, getRelativePathFromCwd, getCleanDate, writeFileIncrement }
+const toBase64 = async (relativePath) => {
+  if (relativePath === '') return ''
+  const absolutePath = path.join(process.cwd(), relativePath)
+  const content = await fs.readFile(absolutePath, { encoding: 'base64' })
+  return `data:image/png;base64,${content}`
+}
+
+export { createDir, cleanDir, readDir, parseImage, adjustCanvas, setFilePermission, renameAndMoveFile, renameAndCopyFile, getRelativePathFromCwd, getCleanDate, writeFileIncrement, toBase64 }


### PR DESCRIPTION
I'm working on this [pull request](https://github.com/kien-ht/cypress-image-diff-html-report/pull/14) at the moment.
This inline assets feature is actually available in the HTML Report package, but turns out it would be better to have this in the core package, as the output JSON could be already base64-ed.