### PR TITLE
feat: Improve failure messages

### DIFF
--- a/cypress-image-diff.config.js
+++ b/cypress-image-diff.config.js
@@ -1,7 +1,8 @@
 const config = {
   ROOT_DIR: '',
   // disableTimersAndAnimations: false is necessary for retry-spec test
-  CYPRESS_SCREENSHOT_OPTIONS: { disableTimersAndAnimations: false }
+  CYPRESS_SCREENSHOT_OPTIONS: { disableTimersAndAnimations: false },
+  FAIL_ON_MISSING_BASELINE: Boolean(process.env.CYPRESS_FAIL_ON_MISSING_BASELINE),
 };
 
 module.exports = config;

--- a/src/command.js
+++ b/src/command.js
@@ -49,11 +49,12 @@ const compareSnapshotCommand = () => {
 
       const defaultRetryOptions = {
         limit: 1,
-        log: (percentage) => {
-          const prefix = percentage <= testThreshold ? 'PASS' : 'FAIL'
+        log: ({percentage, testFailed}) => {
+          const prefix = testFailed ? 'FAIL' : 'PASS'
           cy.log(`${prefix}: Image difference percentage ${percentage}`)
         },
-        error: `Image difference greater than threshold: ${testThreshold}`
+        doNotFail: true,
+        yield: 'value',
       }
 
       recurse(
@@ -85,9 +86,19 @@ const compareSnapshotCommand = () => {
 
           return cy.task('compareSnapshotsPlugin', options)
         },
-        (percentage) => percentage <= testThreshold,
+        ({percentage, missingBaseline}) => {
+          if (missingBaseline) return true
+          return percentage <= testThreshold
+        },
         Object.assign({}, defaultRetryOptions, retryOptions)
-      );
+      ).then(({percentage, testFailed, missingBaseline}) => {
+        if (testFailed) {
+          if (missingBaseline) throw new Error('Missing baseline image')
+
+          const nicePercent = Math.round(percentage * 1000) / 1000
+          throw new Error(`Image difference ${nicePercent} greater than threshold ${testThreshold}`)
+        }
+      });
     }
   )
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -70,8 +70,8 @@ const getStatsComparisonAndPopulateDiffIfAny = async (args) => {
     baselineImg = await parseImage(paths.image.baseline(args.testName))
   } catch (e) {
     return args.failOnMissingBaseline
-      ? { percentage: 1, testFailed: true }
-      : { percentage: 0, testFailed: false }
+      ? { testFailed: true, missingBaseline: true }
+      : { testFailed: false }
   }
   let comparisonImg
   try {
@@ -125,7 +125,7 @@ const getStatsComparisonAndPopulateDiffIfAny = async (args) => {
 }
 
 async function compareSnapshotsPlugin(args) {
-  const { percentage, testFailed } = await getStatsComparisonAndPopulateDiffIfAny(args)
+  const { percentage, testFailed, missingBaseline } = await getStatsComparisonAndPopulateDiffIfAny(args)
 
   // Saving test status object to build report if task is triggered
   let newTest = new TestStatus({
@@ -156,7 +156,11 @@ async function compareSnapshotsPlugin(args) {
 
   testStatuses.push(newTest)
 
-  return percentage
+  return {
+    testFailed,
+    percentage,
+    missingBaseline,
+  }
 }
 
 const generateJsonReport = async (results) => {


### PR DESCRIPTION
Currently when an image comparison assertion fails we just see the message:

```
Error: Image difference greater than threshold: <threshold>
```

This PR improves the failure messages to either:
- `Image difference <diff_percentage> greater than threshold <threshold>`, or
- `Missing baseline image` if the `FAIL_ON_MISSING_BASELINE` option is set

----

This was tested manually:

```
rm cypress-image-diff-screenshots/baseline/retry.cy-retry.png
CYPRESS_FAIL_ON_MISSING_BASELINE=1 npx cypress run
```
=> Error: Missing baseline image

Apply:
```diff
diff --git a/retry-example.html b/retry-example.html
index 4ecd7e3..c6f909d 100644
--- a/retry-example.html
+++ b/retry-example.html
@@ -7,7 +7,7 @@
     <title>Wdio Image Diff Report</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
   </head>
-  <body style="display: none;">
+  <body style="display: block;">
     <p>This message will appear after 3 seconds.</p>
     <script>
       setTimeout(() => {
```
then:
```sh
npx cypress run
```
=> All specs pass

```
git checkout retry-example.html 
npx cypress run
```
=> All specs pass

Manually edit and add a scribble to `cypress-image-diff-screenshots/baseline/retry.cy-retry.png`
```sh
npx cypress run
```
=> Error: Image difference 0.023 greater than threshold 0